### PR TITLE
chore: upgrade to solana v1.14.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solana-accountsdb-plugin-kafka"
 description = "Solana AccountsDb plugin for Kafka"
 authors = ["Blockdaemon"]
-version = "0.1.3+solana.1.10.32"
+version = "0.1.3+solana.1.14.15"
 edition = "2021"
 repository = "https://github.com/Blockdaemon/solana-accountsdb-plugin-kafka"
 license = "Apache-2.0"
@@ -13,10 +13,10 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 prost = "0.11"
 rdkafka = { version = "0.29.0", features = ["ssl-vendored", "sasl"] }
-solana-geyser-plugin-interface = { version = "=1.13.5" }
-solana-logger = { version = "=1.13.5" }
-solana-program = { version = "=1.13.5" }
-solana-transaction-status = { version = "=1.13.5" }
+solana-geyser-plugin-interface = { version = "=1.14.15" }
+solana-logger = { version = "=1.14.15" }
+solana-program = { version = "=1.14.15" }
+solana-transaction-status = { version = "=1.14.15" }
 log = "0.4"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -32,6 +32,8 @@ message UpdateAccountEvent {
   // with higher write_version should supersede the one with lower
   // write_version.
   uint64 write_version = 8;
+
+  bytes txn_signature = 9;
 }
 
 message SlotStatusEvent {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+edition = "2021"
+imports_granularity = "Crate"
+max_width = 80

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,19 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use {
-    rdkafka::{
-        config::FromClientConfig,
-        error::KafkaResult,
-        producer::{DefaultProducerContext, ThreadedProducer},
-        ClientConfig,
-    },
-    serde::Deserialize,
-    solana_geyser_plugin_interface::geyser_plugin_interface::{
-        GeyserPluginError, Result as PluginResult,
-    },
-    std::{collections::HashMap, fs::File, path::Path},
+use rdkafka::{
+    config::FromClientConfig,
+    error::KafkaResult,
+    producer::{DefaultProducerContext, ThreadedProducer},
+    ClientConfig,
 };
+use serde::Deserialize;
+use solana_geyser_plugin_interface::geyser_plugin_interface::{
+    GeyserPluginError, Result as PluginResult,
+};
+use std::{collections::HashMap, fs::File, path::Path};
 
 /// Plugin config.
 #[derive(Deserialize)]
@@ -85,8 +83,9 @@ impl Config {
     /// Read plugin from JSON file.
     pub fn read_from<P: AsRef<Path>>(config_path: P) -> PluginResult<Self> {
         let file = File::open(config_path)?;
-        let mut this: Self = serde_json::from_reader(file)
-            .map_err(|e| GeyserPluginError::ConfigFileReadError { msg: e.to_string() })?;
+        let mut this: Self = serde_json::from_reader(file).map_err(|e| {
+            GeyserPluginError::ConfigFileReadError { msg: e.to_string() }
+        })?;
         this.fill_defaults();
         Ok(this)
     }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -210,16 +210,14 @@ impl Allowlist {
             Err(ureq::Error::Status(code, _response)) => {
                 return Err(PluginError::Custom(Box::new(
                     simple_error::SimpleError::new(format!(
-                        "Failed to fetch allowlist from remote server: status {}",
-                        code
+                        "Failed to fetch allowlist from remote server: status {code}"
                     )),
                 )));
             }
             Err(e) => {
                 return Err(PluginError::Custom(Box::new(
                     simple_error::SimpleError::new(format!(
-                        "Failed to fetch allowlist from remote server: status {}",
-                        e
+                        "Failed to fetch allowlist from remote server: status {e}"
                     )),
                 )));
             }
@@ -467,7 +465,7 @@ mod tests {
                 .with_body("{\"programAllowlist\":[]}")
                 .create();
             let last_updated = allowlist.get_last_updated();
-            println!("last_updated: {:?}", last_updated);
+            println!("last_updated: {last_updated:?}");
             allowlist.update_from_http().unwrap();
             assert_ne!(allowlist.get_last_updated(), last_updated);
             assert_eq!(allowlist.len(), 0);

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::{Arc, Mutex};
-use {
-    crate::*,
-    solana_geyser_plugin_interface::geyser_plugin_interface::GeyserPluginError as PluginError,
-    solana_geyser_plugin_interface::geyser_plugin_interface::Result as PluginResult,
-    solana_program::pubkey::Pubkey,
-    std::{collections::HashSet, str::FromStr},
+use crate::*;
+use solana_geyser_plugin_interface::geyser_plugin_interface::{
+    GeyserPluginError as PluginError, Result as PluginResult,
+};
+use solana_program::pubkey::Pubkey;
+use std::{
+    collections::HashSet,
+    str::FromStr,
+    sync::{Arc, Mutex},
 };
 
 pub struct Filter {
@@ -109,7 +111,9 @@ impl Allowlist {
         if !config.program_allowlist_url.is_empty() {
             let mut out = Self::new_from_http(
                 &config.program_allowlist_url.clone(),
-                std::time::Duration::from_secs(config.program_allowlist_expiry_sec),
+                std::time::Duration::from_secs(
+                    config.program_allowlist_expiry_sec,
+                ),
             )
             .unwrap();
 
@@ -123,7 +127,9 @@ impl Allowlist {
         } else {
             Ok(Self {
                 list: Arc::new(Mutex::new(HashSet::new())),
-                http_last_updated: Arc::new(Mutex::new(std::time::Instant::now())),
+                http_last_updated: Arc::new(Mutex::new(
+                    std::time::Instant::now(),
+                )),
                 http_url: "".to_string(),
                 http_update_interval: std::time::Duration::from_secs(0),
                 http_updater_one: Arc::new(Mutex::new(())),
@@ -294,7 +300,10 @@ impl Allowlist {
         }
     }
 
-    pub fn new_from_http(url: &str, interval: std::time::Duration) -> PluginResult<Self> {
+    pub fn new_from_http(
+        url: &str,
+        interval: std::time::Duration,
+    ) -> PluginResult<Self> {
         let mut interval = interval;
         if interval < std::time::Duration::from_secs(1) {
             interval = std::time::Duration::from_secs(1);
@@ -362,7 +371,8 @@ mod tests {
             ..Config::default()
         };
 
-        let allowlist = Allowlist::new_from_vec(config.program_allowlist).unwrap();
+        let allowlist =
+            Allowlist::new_from_vec(config.program_allowlist).unwrap();
         assert_eq!(allowlist.len(), 2);
 
         assert!(allowlist.wants_program(
@@ -393,9 +403,15 @@ mod tests {
             .create();
 
         let config = Config {
-            program_allowlist_url: [mockito::server_url(), "/allowlist.txt".to_owned()].join(""),
+            program_allowlist_url: [
+                mockito::server_url(),
+                "/allowlist.txt".to_owned(),
+            ]
+            .join(""),
             program_allowlist_expiry_sec: 3,
-            program_allowlist: vec!["WormT3McKhFJ2RkiGpdw9GKvNCrB2aB54gb2uV9MfQC".to_owned()],
+            program_allowlist: vec![
+                "WormT3McKhFJ2RkiGpdw9GKvNCrB2aB54gb2uV9MfQC".to_owned(),
+            ],
             ..Config::default()
         };
 
@@ -437,9 +453,11 @@ mod tests {
             assert_eq!(allowlist.len(), 1);
 
             assert!(allowlist.wants_program(
-                &Pubkey::from_str("9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin")
-                    .unwrap()
-                    .to_bytes()
+                &Pubkey::from_str(
+                    "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
+                )
+                .unwrap()
+                .to_bytes()
             ));
         }
         {
@@ -456,9 +474,11 @@ mod tests {
             println!("last_updated: {:?}", allowlist.get_last_updated());
 
             assert!(allowlist.wants_program(
-                &Pubkey::from_str("9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin")
-                    .unwrap()
-                    .to_bytes()
+                &Pubkey::from_str(
+                    "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
+                )
+                .unwrap()
+                .to_bytes()
             ));
         }
         {
@@ -483,20 +503,26 @@ mod tests {
             assert_ne!(allowlist.get_last_updated(), last_updated);
 
             assert!(allowlist.wants_program(
-                &Pubkey::from_str("Sysvar1111111111111111111111111111111111111")
-                    .unwrap()
-                    .to_bytes()
+                &Pubkey::from_str(
+                    "Sysvar1111111111111111111111111111111111111"
+                )
+                .unwrap()
+                .to_bytes()
             ));
             assert!(allowlist.wants_program(
-                &Pubkey::from_str("Vote111111111111111111111111111111111111111")
-                    .unwrap()
-                    .to_bytes()
+                &Pubkey::from_str(
+                    "Vote111111111111111111111111111111111111111"
+                )
+                .unwrap()
+                .to_bytes()
             ));
             // negative test
             assert!(!allowlist.wants_program(
-                &Pubkey::from_str("9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin")
-                    .unwrap()
-                    .to_bytes()
+                &Pubkey::from_str(
+                    "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
+                )
+                .unwrap()
+                .to_bytes()
             ));
 
             std::thread::sleep(std::time::Duration::from_secs(3));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,13 +20,11 @@ mod filter;
 mod plugin;
 mod publisher;
 
-pub use {
-    config::{Config, Producer},
-    event::*,
-    filter::Filter,
-    plugin::KafkaPlugin,
-    publisher::Publisher,
-};
+pub use config::{Config, Producer};
+pub use event::*;
+pub use filter::Filter;
+pub use plugin::KafkaPlugin;
+pub use publisher::Publisher;
 
 #[no_mangle]
 #[allow(improper_ctypes_definitions)]

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use log::error;
+
 use {
     crate::*,
     prost::Message,
@@ -77,6 +79,8 @@ impl Publisher {
 
 impl Drop for Publisher {
     fn drop(&mut self) {
-        self.producer.flush(self.shutdown_timeout);
+        if let Err(e) = self.producer.flush(self.shutdown_timeout) {
+            error!("Failed to flush producer: {}", e);
+        }
     }
 }

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -14,15 +14,13 @@
 
 use log::error;
 
-use {
-    crate::*,
-    prost::Message,
-    rdkafka::{
-        error::KafkaError,
-        producer::{BaseRecord, Producer as KafkaProducer},
-    },
-    std::time::Duration,
+use crate::*;
+use prost::Message;
+use rdkafka::{
+    error::KafkaError,
+    producer::{BaseRecord, Producer as KafkaProducer},
 };
+use std::time::Duration;
 
 pub struct Publisher {
     producer: Producer,
@@ -44,7 +42,10 @@ impl Publisher {
         }
     }
 
-    pub fn update_account(&self, ev: UpdateAccountEvent) -> Result<(), KafkaError> {
+    pub fn update_account(
+        &self,
+        ev: UpdateAccountEvent,
+    ) -> Result<(), KafkaError> {
         let buf = ev.encode_to_vec();
         let record = BaseRecord::<Vec<u8>, _>::to(&self.update_account_topic)
             .key(&ev.pubkey)
@@ -52,15 +53,23 @@ impl Publisher {
         self.producer.send(record).map(|_| ()).map_err(|(e, _)| e)
     }
 
-    pub fn update_slot_status(&self, ev: SlotStatusEvent) -> Result<(), KafkaError> {
+    pub fn update_slot_status(
+        &self,
+        ev: SlotStatusEvent,
+    ) -> Result<(), KafkaError> {
         let buf = ev.encode_to_vec();
-        let record = BaseRecord::<(), _>::to(&self.slot_status_topic).payload(&buf);
+        let record =
+            BaseRecord::<(), _>::to(&self.slot_status_topic).payload(&buf);
         self.producer.send(record).map(|_| ()).map_err(|(e, _)| e)
     }
 
-    pub fn update_transaction(&self, ev: TransactionEvent) -> Result<(), KafkaError> {
+    pub fn update_transaction(
+        &self,
+        ev: TransactionEvent,
+    ) -> Result<(), KafkaError> {
         let buf = ev.encode_to_vec();
-        let record = BaseRecord::<(), _>::to(&self.transaction_topic).payload(&buf);
+        let record =
+            BaseRecord::<(), _>::to(&self.transaction_topic).payload(&buf);
         self.producer.send(record).map(|_| ()).map_err(|(e, _)| e)
     }
 


### PR DESCRIPTION
# Summary

Main goal was to update the account events to the new solana version.

We now `panic!` on account events from previous solana versions.
We also add the signature to the Kafka event.

Transaction events were adapted to handle both versions, mainly copy/paste for now (+ some
minor changes to handle API changes).

## Remainig work

Once we support transaction events we should revisit and add the extra property that the new
version provides to event.
